### PR TITLE
Fix missing fuel values from stacked fuel

### DIFF
--- a/dist/data-final-fixes.lua
+++ b/dist/data-final-fixes.lua
@@ -145,6 +145,7 @@ local function main()
             log("not found ... data.raw[" .. item_type .. "][" .. name .. "]")
         end
     end
+    deadlock.deferred_stacked_item_updates()
 end
 
 walk_technology()


### PR DESCRIPTION
This should resolve the issue pointed out here: https://mods.factorio.com/mod/DeadlockStackingForBobs/discussion/5f9340ae1d95997ad9d699a6

Since I'm still playing 1.0, it'd be swell if you could also update the mod for pre-1.1.  :)