### PR TITLE
Remove reskins-bobs from dependency list

### DIFF
--- a/dist/info.json
+++ b/dist/info.json
@@ -27,7 +27,6 @@
         "?bobtech",
         "?bobwarfare",
         "?ShinyBobGFX",
-        "?reskins-bobs",
         "?bobplates",
         "?bobores",
         "?CircuitProcessing"


### PR DESCRIPTION
There is only one icon in the entire mod assigned in data-final-fixes, and that is the icon for the first chemical plant. You do not need to depend on my mod, I believe, and I would like to reskin some of your stacked items.